### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/nyurik/fast-mvt/compare/v0.1.1...v0.1.2) - 2026-06-06
+
+### Other
+
+- json - mvt Value conversion, minor cleanup ([#4](https://github.com/nyurik/fast-mvt/pull/4))
+
 ## [0.1.1](https://github.com/nyurik/fast-mvt/compare/v0.1.0...v0.1.1) - 2026-06-06
 
 - update readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2](https://github.com/nyurik/fast-mvt/compare/v0.1.1...v0.1.2) - 2026-06-06
 
-### Other
+### New
 
-- json - mvt Value conversion, minor cleanup ([#4](https://github.com/nyurik/fast-mvt/pull/4))
+- json - mvt value conversion ([#4](https://github.com/nyurik/fast-mvt/pull/4))
 
 ## [0.1.1](https://github.com/nyurik/fast-mvt/compare/v0.1.0...v0.1.1) - 2026-06-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.1.1"
+version = "0.1.2"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/nyurik/fast-mvt/compare/v0.1.1...v0.1.2) - 2026-06-06

### Other

- json - mvt Value conversion, minor cleanup ([#4](https://github.com/nyurik/fast-mvt/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).