### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/nyurik/fast-mvt/compare/v0.1.2...v0.1.3) - 2026-06-06
+## [0.2.0](https://github.com/nyurik/fast-mvt/compare/v0.1.2...v0.2.0) - 2026-06-06
 
-### Other
+### Breaking Changes
 
-- chore! MvtFeatureBuilder::id now takes option ([#6](https://github.com/nyurik/fast-mvt/pull/6))
+- MvtFeatureBuilder::id now takes option ([#6](https://github.com/nyurik/fast-mvt/pull/6))
 
 ## [0.1.2](https://github.com/nyurik/fast-mvt/compare/v0.1.1...v0.1.2) - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/nyurik/fast-mvt/compare/v0.1.2...v0.1.3) - 2026-06-06
+
+### Other
+
+- chore! MvtFeatureBuilder::id now takes option ([#6](https://github.com/nyurik/fast-mvt/pull/6))
+
 ## [0.1.2](https://github.com/nyurik/fast-mvt/compare/v0.1.1...v0.1.2) - 2026-06-06
 
 ### New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.1.3"
+version = "0.2.0"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.1.2"
+version = "0.1.3"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/nyurik/fast-mvt/compare/v0.1.2...v0.1.3) - 2026-06-06

### Other

- chore! MvtFeatureBuilder::id now takes option ([#6](https://github.com/nyurik/fast-mvt/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).