### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/nyurik/fast-mvt/compare/v0.2.0...v0.3.0) - 2026-06-06
+
+### Other
+
+- [**breaking**] validate non-empty layer name, fuzz ([#8](https://github.com/nyurik/fast-mvt/pull/8))
+
 ## [0.2.0](https://github.com/nyurik/fast-mvt/compare/v0.1.2...v0.2.0) - 2026-06-06
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/nyurik/fast-mvt/compare/v0.2.0...v0.3.0) - 2026-06-06

### Other

- [**breaking**] validate non-empty layer name, fuzz ([#8](https://github.com/nyurik/fast-mvt/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).