### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/nyurik/fast-mvt/compare/v0.3.0...v0.3.1) - 2026-06-12
+
+### Other
+
+- add more tests ([#12](https://github.com/nyurik/fast-mvt/pull/12))
+- use new buffa with 20% faster decoding ([#10](https://github.com/nyurik/fast-mvt/pull/10))
+
 ## [0.3.0](https://github.com/nyurik/fast-mvt/compare/v0.2.0...v0.3.0) - 2026-06-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/nyurik/fast-mvt/compare/v0.3.0...v0.3.1) - 2026-06-12

### Other

- add more tests ([#12](https://github.com/nyurik/fast-mvt/pull/12))
- use new buffa with 20% faster decoding ([#10](https://github.com/nyurik/fast-mvt/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).