### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/nyurik/fast-mvt/compare/v0.3.1...v0.3.2) - 2026-06-17
+
+### Other
+
+- CI release workflow
+- *(deps)* bump codecov/codecov-action ([#14](https://github.com/nyurik/fast-mvt/pull/14))
+- ignore generated files in codecov
+
 ## [0.3.1](https://github.com/nyurik/fast-mvt/compare/v0.3.0...v0.3.1) - 2026-06-12
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.3.1"
+version = "0.3.2"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/nyurik/fast-mvt/compare/v0.3.1...v0.3.2) - 2026-06-17

### Other

- CI release workflow
- *(deps)* bump codecov/codecov-action ([#14](https://github.com/nyurik/fast-mvt/pull/14))
- ignore generated files in codecov
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).