### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/nyurik/fast-mvt/compare/v0.3.2...v0.4.0) - 2026-06-18
+
+### Other
+
+- [**breaking**] use ref geometry, add `encode_ref` support, faster indexer ([#16](https://github.com/nyurik/fast-mvt/pull/16))
+
 ## [0.3.2](https://github.com/nyurik/fast-mvt/compare/v0.3.1...v0.3.2) - 2026-06-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "fast-mvt"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.3.2"
+version = "0.4.0"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.3.2 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/nyurik/fast-mvt/compare/v0.3.2...v0.4.0) - 2026-06-18

### Other

- [**breaking**] use ref geometry, add `encode_ref` support, faster indexer ([#16](https://github.com/nyurik/fast-mvt/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).