### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nyurik/fast-mvt/compare/v0.4.1...v0.4.2) - 2026-07-12
+## [0.5.0](https://github.com/nyurik/fast-mvt/compare/v0.4.1...v0.5.0) - 2026-07-12
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/nyurik/fast-mvt/compare/v0.4.1...v0.4.2) - 2026-07-12
+
+### Other
+
+- debug format support, cleaner api ([#26](https://github.com/nyurik/fast-mvt/pull/26))
+- minor internal cleanup ([#23](https://github.com/nyurik/fast-mvt/pull/23))
+
 ## [0.4.1](https://github.com/nyurik/fast-mvt/compare/v0.4.0...v0.4.1) - 2026-06-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "fast-mvt"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "fast-mvt"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.4.1"
+version = "0.4.2"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.4.2"
+version = "0.5.0"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/nyurik/fast-mvt/compare/v0.4.1...v0.4.2) - 2026-07-12

### Other

- debug format support, cleaner api ([#26](https://github.com/nyurik/fast-mvt/pull/26))
- minor internal cleanup ([#23](https://github.com/nyurik/fast-mvt/pull/23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).