### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/nyurik/fast-mvt/compare/v0.6.0...v0.6.1) - 2026-07-18
+
+### Added
+
+- add tag_auto_int to pick most compact int store ([#30](https://github.com/nyurik/fast-mvt/pull/30))
+
+### Other
+
+- simplify parallel usage, add docs ([#31](https://github.com/nyurik/fast-mvt/pull/31))
+- update readme
+
 ## [0.6.0](https://github.com/nyurik/fast-mvt/compare/v0.5.0...v0.6.0) - 2026-07-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "fast-mvt"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.6.0"
+version = "0.6.1"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/nyurik/fast-mvt/compare/v0.6.0...v0.6.1) - 2026-07-18

### Added

- add tag_auto_int to pick most compact int store ([#30](https://github.com/nyurik/fast-mvt/pull/30))

### Other

- simplify parallel usage, add docs ([#31](https://github.com/nyurik/fast-mvt/pull/31))
- update readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).