### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/nyurik/fast-mvt/compare/v0.6.1...v0.6.2) - 2026-07-20
+
+### Other
+
+- some helper  functions, test cleanup, docs ([#32](https://github.com/nyurik/fast-mvt/pull/32))
+
 ## [0.6.1](https://github.com/nyurik/fast-mvt/compare/v0.6.0...v0.6.1) - 2026-07-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "fast-mvt"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-mvt"
-version = "0.6.1"
+version = "0.6.2"
 description = "Fast Mapbox Vector Tile (MVT) reader and writer"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/fast-mvt"


### PR DESCRIPTION



## 🤖 New release

* `fast-mvt`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.2](https://github.com/nyurik/fast-mvt/compare/v0.6.1...v0.6.2) - 2026-07-20

### Other

- some helper  functions, test cleanup, docs ([#32](https://github.com/nyurik/fast-mvt/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).