### PR TITLE
perf: reserve space for polygon ring closure

### DIFF
--- a/src/geom_reader.rs
+++ b/src/geom_reader.rs
@@ -110,9 +110,10 @@ fn parse_line_slice(
     cursor: &mut MvtCoord,
     data: &[u32],
     info: LineInfo,
+    reserve_closure: bool,
 ) -> MvtResult<MvtLineString> {
     let (_, move_count) = Command::decode(data[0])?;
-    let mut coords = Vec::with_capacity(info.coord_count);
+    let mut coords = Vec::with_capacity(info.coord_count + usize::from(reserve_closure));
     for move_idx in 0..move_count {
         let offset = 1 + move_idx * 2;
         coords.push(decode_coord(cursor, &data[offset..offset + 2])?);
@@ -138,6 +139,7 @@ fn parse_linestrings(data: &[u32]) -> MvtResult<MvtGeometry> {
             &mut cursor,
             &data[offset..offset + info.len],
             info,
+            false,
         )?);
         let len = info.len;
         offset += len;
@@ -167,7 +169,7 @@ fn ring_info(data: &[u32]) -> MvtResult<(LineInfo, usize)> {
 
 fn parse_ring(cursor: &mut MvtCoord, data: &[u32]) -> MvtResult<(MvtLineString, i64, usize)> {
     let (info, len) = ring_info(data)?;
-    let mut ring = parse_line_slice(cursor, &data[..info.len], info)?;
+    let mut ring = parse_line_slice(cursor, &data[..info.len], info, true)?;
     let area = signed_area(&ring.0);
     let first = *ring.0.first().ok_or(MvtError::InvalidGeometry)?;
     ring.0.push(first);
@@ -240,7 +242,7 @@ mod tests {
         let mut cursor = coord! { x: 0, y: 0 };
         let info = line_info(&[9, 0, 0, 15]).unwrap();
         assert!(matches!(
-            parse_line_slice(&mut cursor, &[9, 0, 0, 15], info),
+            parse_line_slice(&mut cursor, &[9, 0, 0, 15], info, false),
             Err(MvtError::InvalidGeometry)
         ));
 
@@ -306,5 +308,33 @@ mod tests {
             parse_polygons(&[9, 0, 0, 8]),
             Err(MvtError::InvalidGeometry)
         ));
+    }
+}
+
+#[cfg(test)]
+mod allocation_tests {
+    use super::*;
+
+    #[test]
+    fn ring_capacity_includes_closure_without_spare_coordinates() {
+        for commands in [
+            vec![9, 0, 0, 26, 20, 0, 0, 20, 19, 0, 15],
+            vec![9, 4, 6, 15],
+            vec![9, 0, 0, 34, 20, 0, 0, 20, 19, 0, 0, 19, 15],
+        ] {
+            let (ring, _, consumed) = parse_ring(&mut MvtCoord::zero(), &commands).unwrap();
+            assert_eq!(consumed, commands.len());
+            assert_eq!(ring.0.capacity(), ring.0.len());
+            assert_eq!(ring.0.first(), ring.0.last());
+        }
+    }
+
+    #[test]
+    fn line_capacity_does_not_include_a_closure_slot() {
+        let commands = [9, 0, 0, 18, 20, 0, 0, 20];
+        let info = line_info(&commands).unwrap();
+        let line = parse_line_slice(&mut MvtCoord::zero(), &commands, info, false).unwrap();
+        assert_eq!(line.0.len(), 3);
+        assert_eq!(line.0.capacity(), 3);
     }
 }


### PR DESCRIPTION
Polygon decoding fills a vector with `coord_count` coordinates, then appends the closing coordinate. That append forces the vector to grow; for example, a four-coordinate ring ends with length 5 and capacity 8.

Reserve the closure slot when allocating a ring, while keeping open-line capacity unchanged. This removes one buffer growth per ring without changing coordinate decoding, signed-area calculation, winding, or hole grouping. Add capacity regression tests for ordinary, move-only, and already-closed rings, plus an open-line control.

Validation against current `main`:

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features --lib --bins --tests --examples` (333 tests passed, including real-world fixtures)
- `cargo test --no-default-features --features reader --lib` (14 passed)
- `cargo test --doc --workspace --all-features` (5 passed)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
